### PR TITLE
Update `frc-sdk` header

### DIFF
--- a/examples/form/index.php
+++ b/examples/form/index.php
@@ -13,8 +13,8 @@ $apikey = getenv('FRC_APIKEY');
 $siteverifyEndpoint = getenv('FRC_SITEVERIFY_ENDPOINT');
 $widgetEndpoint = getenv('FRC_WIDGET_ENDPOINT');
 
-const MODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.7/site.min.js";
-const NOMODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.7/site.compat.min.js";; // Compatibility fallback for old browsers.
+const MODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.8/site.min.js";
+const NOMODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.8/site.compat.min.js";; // Compatibility fallback for old browsers.
 
 if (empty($sitekey) || empty($apikey)) {
     die("Please set the FRC_SITEKEY and FRC_APIKEY environment values before running this example.");

--- a/src/client.php
+++ b/src/client.php
@@ -6,7 +6,7 @@ namespace FriendlyCaptcha\SDK;
 
 use FriendlyCaptcha\SDK\{ClientConfig, VerifyResult, ErrorCodes};
 
-const VERSION = "0.1.0";
+const VERSION = "0.1.1";
 const EU_API_ENDPOINT = "https://eu.frcapi.com/api/v2/captcha/siteverify";
 const GLOBAL_API_ENDPOINT = "https://global.frcapi.com/api/v2/captcha/siteverify";
 
@@ -76,7 +76,7 @@ class Client
                 'Content-Type: application/json',
                 'Content-Length: ' . strlen($payload),
                 'X-Api-Key: ' . $this->config->apiKey,
-                'X-Frc-Sdk: ' . 'friendly-captcha-php-sdk@' . VERSION
+                'Frc-Sdk: ' . 'friendly-captcha-php@' . VERSION
             )
         );
         curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);


### PR DESCRIPTION
No functional changes: making it consistent with other SDKs - changing the name of the header and its value. This header is how we can tell whether people are using the SDK (and if we ever make accidental breaking changes, we could warn users using an old version).