### PR TITLE
Add a method that enables adding an Frc-Sdk component

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -6,7 +6,7 @@ namespace FriendlyCaptcha\SDK;
 
 use FriendlyCaptcha\SDK\{ClientConfig, VerifyResult, ErrorCodes};
 
-const VERSION = "0.1.1";
+const VERSION = "0.1.2";
 const EU_API_ENDPOINT = "https://eu.frcapi.com/api/v2/captcha/siteverify";
 const GLOBAL_API_ENDPOINT = "https://global.frcapi.com/api/v2/captcha/siteverify";
 

--- a/src/client.php
+++ b/src/client.php
@@ -54,6 +54,11 @@ class Client
             $requestFields["sitekey"] = $this->config->sitekey;
         }
 
+        $frcSdk = 'friendly-captcha-php@' . VERSION;
+        if ($this->config->sdkTrailer != "") {
+            $frcSdk = $frcSdk . "; " . $this->config->sdkTrailer;
+        }
+
         $payload = json_encode($requestFields);
         if ($payload === false) {
             // TODO: should we put `json_last_error()` somewhere on the object?
@@ -76,7 +81,7 @@ class Client
                 'Content-Type: application/json',
                 'Content-Length: ' . strlen($payload),
                 'X-Api-Key: ' . $this->config->apiKey,
-                'Frc-Sdk: ' . 'friendly-captcha-php@' . VERSION
+                'Frc-Sdk: ' . $frcSdk,
             )
         );
         curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);

--- a/src/config.php
+++ b/src/config.php
@@ -10,6 +10,7 @@ class ClientConfig
 {
     public $apiKey = "";
     public $sitekey = "";
+    public $sdkTrailer = "";
     public $siteverifyEndpoint = "global";
     public $strict = false;
     public $timeout = 30;
@@ -34,6 +35,21 @@ class ClientConfig
     public function setSitekey(string $sitekey): self
     {
         $this->sitekey = $sitekey;
+        return $this;
+    }
+
+    /**
+     * An "Frc-Sdk" HTTP header is sent as part of the API request to identify the SDK being used to initiate the request.
+     * A downstream SDK might depend on *this* SDK, so this function is provided to allow the downstream SDK to append an
+     * identifier to uniquely identify it. For example, this library sends an "Frc-Sdk" header of
+     * `friendly-captcha-php@1.2.3`. If `friendly-captcha-wordpress` depends on it, it can add a trailer so that requests
+     * will use an "Frc-Sdk" header of `friendly-captcha-php@1.2.3; friendly-captcha-wordpress@4.5.6`.
+     *
+     * @param string $sdk an identifier that describes the component that depends on this SDK.
+     */
+    public function setSDKTrailer(string $sdkTrailer): self
+    {
+        $this->sdkTrailer = $sdkTrailer;
         return $this;
     }
 

--- a/tests/verifyTest.php
+++ b/tests/verifyTest.php
@@ -7,6 +7,7 @@ namespace FriendlyCaptcha\SDK\Test;
 use FriendlyCaptcha\SDK\{Client, ClientConfig};
 use Exception;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 const MOCK_SERVER_URL = "http://localhost:1090";
@@ -86,6 +87,7 @@ final class VerifyTest extends TestCase
     /**
      * @dataProvider sdkMockTestsProvider
      */
+    #[DataProvider('sdkMockTestsProvider')]
     public function testSDKTestServerCase($test): void
     {
         $opts = new ClientConfig();


### PR DESCRIPTION
This will allow SDKs that depend on the PHP SDK to add an identifier that identifies them.

PHPUnit v10 changed the implementation of Data Providers, so I updated the tests accordingly.