### PR TITLE
Add support for Risk Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # friendly-captcha-php
 
-A PHP client for the [Friendly Captcha](https://friendlycaptcha.com) service. This client allows for easy integration and verification of captcha responses with the Friendly Captcha API.
+A PHP client for the [Friendly Captcha](https://friendlycaptcha.com) service. This client makes it easy to connect to the Friendly Captcha API for captcha verification or [Risk Intelligence](https://developer.friendlycaptcha.com/docs/v2/risk-intelligence/) retrieval.
 
 > Note, this is for [Friendly Captcha v2](https://developer.friendlycaptcha.com) only.
 
@@ -16,7 +16,11 @@ composer require friendlycaptcha/sdk
 
 ## Usage
 
-First configure and create a SDK client
+Below are some basic examples that demonstrate how to use this SDK.
+
+For complete examples, take a look at the [examples](./examples/) directory.
+
+### Initialization
 
 ```php
 use FriendlyCaptcha\SDK\{Client, ClientConfig}
@@ -25,12 +29,12 @@ $config = new ClientConfig();
 $config->setAPIKey("<YOUR API KEY>")->setSitekey("<YOUR SITEKEY (optional)>");
 
 // You can also specify which endpoint to use, for example `"global"` or `"eu"`.
-// $config->setEndpoint("eu")
+// $config->setApiEndpoint("eu")
 
 $captchaClient = new Client($config)
 ```
 
-Then use it in the endpoint you want to protect
+### Verifying a Captcha Response
 
 ```php
 function handleLoginRequest() {
@@ -58,6 +62,38 @@ function handleLoginRequest() {
 
     // The captcha is accepted, handle the request:
     loginUser($_POST["username"], $_POST["password"]);
+}
+```
+
+### Retrieving Risk Intelligence
+
+You can retrieve [Risk Intelligence](https://developer.friendlycaptcha.com/docs/v2/risk-intelligence/) data using a token. This data provides detailed information about the risk profile of a request, including network data, geolocation, browser details, and risk scores.
+
+```php
+function getRiskIntelligence() {
+    global $frcClient;
+
+    $token = isset($_POST["frc-risk-intelligence-token"]) ? $_POST["frc-risk-intelligence-token"] : null;
+    $result = $frcClient->retrieveRiskIntelligence($token);
+
+    if ($result->wasAbleToRetrieve()) {
+        // Risk Intelligence token is valid and data was retrieved successfully.
+        if ($result->isValid()) {
+            // Token was invalid or expired. 
+            $response = $result->getResponse();
+            echo "Risk Intelligence data", $response->data;
+        } else {
+            $error = $result->getResponseError();
+            error_log("Error:", $error);
+        }
+    } else {
+        // Network issue or configuration problem.
+        if ($result->isClientError()) {
+            error_log("Configuration error - check your API key");
+        } else {
+            error_log("Network issue or service temporarily unavailable");
+        }
+    }
 }
 ```
 
@@ -111,16 +147,14 @@ OK (28 tests, 110 assertions)
 
 ### Optional
 
-Install an old version of PHP (to be sure it works in that version). The oldest PHP version this SDK supports is 7.1.
+To make sure that the SDK is backwards compatible, make sure the tests pass in PHP 7.1. We recommend using Docker.
 
-```php
-brew install shivammathur/php/php@7.1
-echo 'export PATH="/opt/homebrew/opt/php@7.1/bin:$PATH"' >> ~/.zshrc
-echo 'export PATH="/opt/homebrew/opt/php@7.1/sbin:$PATH"' >> ~/.zshrc
-
-# open a new terminal and check the new version
-php --version
+```console
+$ docker run --rm -it --network host -v $PWD:/php -w /php php:7.1-alpine /bin/sh
+/php # apk update && apk add git
 ```
+
+Then follow the steps above starting with [**Install Composer**](#install-composer). You can run `./friendly-captcha-sdk-testserver serve` outside the Docker container.
 
 ### Some features you can't use to be compatible with PHP 7.1
 

--- a/examples/form/README.md
+++ b/examples/form/README.md
@@ -1,6 +1,6 @@
 # form
 
-Example of using the Friendly Captcha SDK for PHP.
+Example of using the Friendly Captcha SDK for PHP. It displays a form with a captcha and verifies the captcha response on the back-end. If the application has [**Risk Intelligence**](https://developer.friendlycaptcha.com/docs/v2/risk-intelligence/) enabled, it will also generate a token and use it to retrieve the Risk Intelligence data.
 
 ## Running the example
 
@@ -11,7 +11,7 @@ FRC_APIKEY=YOUR_API_KEY FRC_SITEKEY=YOUR_SITEKEY php -S localhost:8000
 Alternatively, you can also specify custom endpoints:
 
 ```shell
-FRC_SITEKEY=YOUR_API_KEY FRC_APIKEY=YOUR_SITEKEY FRC_SITEVERIFY_ENDPOINT=https://eu-dev.frcapi.com/api/v2/captcha/siteverify FRC_WIDGET_ENDPOINT=https://eu-dev.frcapi.com/api/v2/captcha php -S localhost:8000
+FRC_SITEKEY=YOUR_API_KEY FRC_APIKEY=YOUR_SITEKEY FRC_API_ENDPOINT=https://eu-dev.frcapi.com FRC_WIDGET_ENDPOINT=https://eu-dev.frcapi.com php -S localhost:8000
 ```
 
 Now open your browser and navigate to [http://localhost:8000](http://localhost:8000).

--- a/examples/form/index.php
+++ b/examples/form/index.php
@@ -10,17 +10,17 @@ $sitekey = getenv('FRC_SITEKEY');
 $apikey = getenv('FRC_APIKEY');
 
 // Optionally we can pass in custom endpoints to be used, such as "eu".
-$siteverifyEndpoint = getenv('FRC_SITEVERIFY_ENDPOINT');
+$apiEndpoint = getenv('FRC_API_ENDPOINT');
 $widgetEndpoint = getenv('FRC_WIDGET_ENDPOINT');
 
-const MODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.8/site.min.js";
-const NOMODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.8/site.compat.min.js";; // Compatibility fallback for old browsers.
+const MODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.min.js";
+const NOMODULE_SCRIPT_URL = "https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.compat.min.js";; // Compatibility fallback for old browsers.
 
 if (empty($sitekey) || empty($apikey)) {
     die("Please set the FRC_SITEKEY and FRC_APIKEY environment values before running this example.");
 }
 
-function generateForm(bool $didSubmit, bool $captchaOK, string $sitekey)
+function generateForm(bool $didSubmit, bool $captchaOK, string $sitekey, string $riskIntelligence)
 {
     global $widgetEndpoint;
     $html = '';
@@ -31,10 +31,12 @@ function generateForm(bool $didSubmit, bool $captchaOK, string $sitekey)
         } else {
             $html .= '<p style="color:#ba1f1f">❌ Anti-robot check failed, please try again.<br>See console output for details.</p>';
         }
+        if (!empty($riskIntelligence)) {
+            $html .= $riskIntelligence;
+        }
         $html .= '<a href=".">Back to form</a>';
-    }
-
-    if (!$didSubmit) {
+    } else {
+        $dataEndpoint = empty($widgetEndpoint) ? "" : (' data-api-endpoint="' . $widgetEndpoint . '"');
         $html .= '
         <form method="POST">
             <div class="form-group">
@@ -42,9 +44,8 @@ function generateForm(bool $didSubmit, bool $captchaOK, string $sitekey)
                 <input type="text" name="name" value="Jane Doe"><br />
                 <label>Message:</label><br />
                 <textarea name="message"></textarea><br />
-                <div class="frc-captcha"
-                  data-sitekey="' . $sitekey . '"' .
-            (isset($widgetEndpoint) ? (' data-api-endpoint="' . $widgetEndpoint . '"') : '') . '></div> 
+                <div class="frc-captcha" data-sitekey="' . $sitekey . '"' . $dataEndpoint . '></div> 
+                <div class="frc-risk-intelligence" data-sitekey="' . $sitekey . '"' . $dataEndpoint . '></div>
                 <input style="margin-top: 1em" type="submit" value="Submit">
             </div>
         </form>';
@@ -55,14 +56,16 @@ function generateForm(bool $didSubmit, bool $captchaOK, string $sitekey)
 $config = new \FriendlyCaptcha\SDK\ClientConfig();
 $config->setAPIKey($apikey);
 $config->setSitekey($sitekey);
-if (!empty($siteverifyEndpoint)) {
-    $config->setSiteverifyEndpoint($siteverifyEndpoint); // Optional, it defaults to "global".
+if (!empty($apiEndpoint)) {
+    $config->setApiEndpoint($apiEndpoint); // Optional, it defaults to "global".
 }
 
 $frcClient = new \FriendlyCaptcha\SDK\Client($config);
 
 $didSubmit = $_SERVER['REQUEST_METHOD'] === 'POST';
 $captchaOK = false;
+
+$riskIntelligence = "";
 
 if ($didSubmit) {
     $captchaResponse = isset($_POST["frc-captcha-response"]) ? $_POST["frc-captcha-response"] : null;
@@ -91,6 +94,30 @@ if ($didSubmit) {
         // In this example we will simply print the message to the console using `error_log`.
         error_log("Message submitted by \"" . $name . "\": \"" . $message . "\"");
     }
+
+    $riskIntelligenceToken = isset($_POST["frc-risk-intelligence-token"]) ? $_POST["frc-risk-intelligence-token"] : null;
+    $result = $frcClient->retrieveRiskIntelligence($riskIntelligenceToken);
+    if ($result->wasAbleToRetrieve()) {
+        if ($result->isValid()) {
+            $data = $result->getResponse()->data->risk_intelligence;
+            $riskIntelligence = '
+            <h3>Risk Intelligence Data</h3>
+            <dl>
+                <dt>Location</dt>
+                <dd>' . $data->network->geolocation->city . ', ' . $data->network->geolocation->country->name . '</dd>
+                <dt>Device</dt>
+                <dd><i>Make:</i> ' . $data->client->device->brand . '<br><i>Model:</i> ' . $data->client->device->model . '</dd>
+                <dt>Overall Risk Score</dt>
+                <dd>' . $data->risk_scores->overall . '</dd>
+            </dl>
+            ';
+        } else {
+            $error = $result->getResponseError();
+            error_log("Friendly Captcha API Error:", $error);
+        }
+    } else {
+        error_log("Failed to make the request", $result->errorCode);
+    }
 }
 ?>
 
@@ -112,7 +139,7 @@ if ($didSubmit) {
 <body>
     <main>
         <h1>PHP Form Example</h1>
-        <?php echo generateForm($didSubmit, $captchaOK, $sitekey); ?>
+        <?php echo generateForm($didSubmit, $captchaOK, $sitekey, $riskIntelligence); ?>
     </main>
 
     <script>

--- a/src/client.php
+++ b/src/client.php
@@ -40,7 +40,7 @@ class Client
         $this->resolvedApiEndpoint = $endpoint;
     }
 
-    public function verifyCaptchaResponse(?string $response): VerifyResult
+    public function verifyCaptchaResponse(?string $response, string $sitekey = ""): VerifyResult
     {
         $verifyResult = new VerifyResult($this->config->strict);
         $verifyResult->status = -1; // So that it is always set, this will only be -1 if the request fails.
@@ -51,8 +51,8 @@ class Client
         }
         $requestFields = array("response" => $response);
     
-        if ($this->config->sitekey != "") {
-            $requestFields["sitekey"] = $this->config->sitekey;
+        if ($sitekey != "" || $this->config->sitekey != "") {
+            $requestFields["sitekey"] = $sitekey ?: $this->config->sitekey;
         }
 
         $frcSdk = 'friendly-captcha-php@' . VERSION;

--- a/src/client.php
+++ b/src/client.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace FriendlyCaptcha\SDK;
 
-use FriendlyCaptcha\SDK\{ClientConfig, VerifyResult, ErrorCodes};
+use FriendlyCaptcha\SDK\{ClientConfig, VerifyResult, RiskIntelligenceRetrieveResult, ErrorCodes};
 
 const VERSION = "0.2.0";
 const EU_API_ENDPOINT = "https://eu.frcapi.com";
 const GLOBAL_API_ENDPOINT = "https://global.frcapi.com";
 const SITEVERIFY_PATH = "/api/v2/captcha/siteverify";
+const RETRIEVE_PATH = "/api/v2/riskIntelligence/retrieve";
 
 class Client
 {
@@ -40,35 +41,25 @@ class Client
         $this->resolvedApiEndpoint = $endpoint;
     }
 
-    public function verifyCaptchaResponse(?string $response, string $sitekey = ""): VerifyResult
+    /**
+     * Makes a POST request to the API and returns the HTTP status and response body.
+     * Returns ['status' => int, 'body' => string] on success, or ['errorCode' => string] on failure.
+     */
+    private function makeRequest(string $path, array $fields): array
     {
-        $verifyResult = new VerifyResult($this->config->strict);
-        $verifyResult->status = -1; // So that it is always set, this will only be -1 if the request fails.
-
-        
-        if ($response === null) {
-            $response = "";
-        }
-        $requestFields = array("response" => $response);
-    
-        if ($sitekey != "" || $this->config->sitekey != "") {
-            $requestFields["sitekey"] = $sitekey ?: $this->config->sitekey;
-        }
-
         $frcSdk = 'friendly-captcha-php@' . VERSION;
         if ($this->config->sdkTrailer != "") {
             $frcSdk = $frcSdk . "; " . $this->config->sdkTrailer;
         }
 
-        $payload = json_encode($requestFields);
+        $payload = json_encode($fields);
         if ($payload === false) {
-            // TODO: should we put `json_last_error()` somewhere on the object?
-            $verifyResult->errorCode = ErrorCodes::$FailedToEncodeRequest;
-            return $verifyResult;
+            // TODO: should we expose `json_last_error()`?
+            return ['errorCode' => ErrorCodes::$FailedToEncodeRequest];
         }
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->resolvedApiEndpoint . SITEVERIFY_PATH);
+        curl_setopt($ch, CURLOPT_URL, $this->resolvedApiEndpoint . $path);
         curl_setopt($ch, CURLOPT_POST, true);
 
         // Return response instead of outputting
@@ -91,32 +82,81 @@ class Client
 
         $resp = curl_exec($ch);
 
-
         if ($resp === false) {
-            // TODO: should we put `curl_errno($ch)` somewhere on the object?           
-            $verifyResult->errorCode = ErrorCodes::$RequestFailed;
+            // TODO: should we expose `curl_errno($ch)`?
             curl_close($ch);
+            return ['errorCode' => ErrorCodes::$RequestFailed];
+        }
+
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return ['status' => $status, 'body' => $resp];
+    }
+
+    public function verifyCaptchaResponse(?string $response, string $sitekey = ""): VerifyResult
+    {
+        $verifyResult = new VerifyResult($this->config->strict);
+        $verifyResult->status = -1; // So that it is always set, this will only be -1 if the request fails.
+
+        $fields = array("response" => $response ?? "");
+        if ($sitekey != "" || $this->config->sitekey != "") {
+            $fields["sitekey"] = $sitekey ?: $this->config->sitekey;
+        }
+
+        $apiResult = $this->makeRequest(SITEVERIFY_PATH, $fields);
+        if (isset($apiResult['errorCode'])) {
+            $verifyResult->errorCode = $apiResult['errorCode'];
             return $verifyResult;
         }
 
-        // Get HTTP status code
-        $verifyResult->status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $verifyResult->status = $apiResult['status'];
 
-        curl_close($ch);
-
-        $response = VerifyResponse::fromJson($resp);
-        if ($response == null) {
-            // TODO: should we put `json_last_error()` somewhere on the object?
+        $parsedResponse = VerifyResponse::fromJson($apiResult['body']);
+        if ($parsedResponse == null) {
+            // TODO: should we expose `json_last_error()`?
             $verifyResult->errorCode = ErrorCodes::$FailedToDecodeResponse;
             return $verifyResult;
         }
-        $verifyResult->response = $response;
+        $verifyResult->response = $parsedResponse;
 
         if ($verifyResult->status >= 400 && $verifyResult->status < 500) {
             $verifyResult->errorCode = ErrorCodes::$FailedDueToClientError;
-            return $verifyResult;
         }
 
         return $verifyResult;
+    }
+
+    public function retrieveRiskIntelligence(?string $token, string $sitekey = ""): RiskIntelligenceRetrieveResult
+    {
+        $result = new RiskIntelligenceRetrieveResult();
+        $result->status = -1; // So that it is always set, this will only be -1 if the request fails.
+
+        $fields = array("token" => $token ?? "");
+        if ($sitekey != "" || $this->config->sitekey != "") {
+            $fields["sitekey"] = $sitekey ?: $this->config->sitekey;
+        }
+
+        $apiResult = $this->makeRequest(RETRIEVE_PATH, $fields);
+        if (isset($apiResult['errorCode'])) {
+            $result->errorCode = $apiResult['errorCode'];
+            return $result;
+        }
+
+        $result->status = $apiResult['status'];
+
+        $parsedResponse = RiskIntelligenceRetrieveResponse::fromJson($apiResult['body']);
+        if ($parsedResponse == null) {
+            // TODO: should we expose `json_last_error()`?
+            $result->errorCode = ErrorCodes::$FailedToDecodeResponse;
+            return $result;
+        }
+        $result->response = $parsedResponse;
+
+        if ($result->status >= 400 && $result->status < 500) {
+            $result->errorCode = ErrorCodes::$FailedDueToClientError;
+        }
+
+        return $result;
     }
 }

--- a/src/client.php
+++ b/src/client.php
@@ -6,9 +6,10 @@ namespace FriendlyCaptcha\SDK;
 
 use FriendlyCaptcha\SDK\{ClientConfig, VerifyResult, ErrorCodes};
 
-const VERSION = "0.1.2";
-const EU_API_ENDPOINT = "https://eu.frcapi.com/api/v2/captcha/siteverify";
-const GLOBAL_API_ENDPOINT = "https://global.frcapi.com/api/v2/captcha/siteverify";
+const VERSION = "0.2.0";
+const EU_API_ENDPOINT = "https://eu.frcapi.com";
+const GLOBAL_API_ENDPOINT = "https://global.frcapi.com";
+const SITEVERIFY_PATH = "/api/v2/captcha/siteverify";
 
 class Client
 {
@@ -16,9 +17,9 @@ class Client
     private $config;
 
     /**
-     * @var string the resolved siteverify endpoint, with any shorthands resolved to their full URL.
+     * @var string the resolved API endpoint, with any shorthands resolved to their full URL.
      */
-    private $resolvedSiteverifyEndpoint;
+    private $resolvedApiEndpoint;
 
     public function __construct(ClientConfig $config)
     {
@@ -28,7 +29,7 @@ class Client
             throw new \Exception("API key is required");
         }
 
-        $endpoint = $this->config->siteverifyEndpoint;
+        $endpoint = $this->config->apiEndpoint ?: $this->config->siteverifyEndpoint ?: "global";
 
         if ($endpoint === "eu") {
             $endpoint = EU_API_ENDPOINT;
@@ -36,7 +37,7 @@ class Client
             $endpoint = GLOBAL_API_ENDPOINT;
         }
 
-        $this->resolvedSiteverifyEndpoint = $endpoint;
+        $this->resolvedApiEndpoint = $endpoint;
     }
 
     public function verifyCaptchaResponse(?string $response): VerifyResult
@@ -67,7 +68,7 @@ class Client
         }
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $this->resolvedSiteverifyEndpoint);
+        curl_setopt($ch, CURLOPT_URL, $this->resolvedApiEndpoint . SITEVERIFY_PATH);
         curl_setopt($ch, CURLOPT_POST, true);
 
         // Return response instead of outputting

--- a/src/config.php
+++ b/src/config.php
@@ -11,7 +11,8 @@ class ClientConfig
     public $apiKey = "";
     public $sitekey = "";
     public $sdkTrailer = "";
-    public $siteverifyEndpoint = "global";
+    public $apiEndpoint = "";
+    public $siteverifyEndpoint = "";
     public $strict = false;
     public $timeout = 30;
     public $connectTimeout = 20;
@@ -54,12 +55,34 @@ class ClientConfig
     }
 
     /**
-     * @param string $siteverifyEndpoint a full URL, or the shorthands `"global"` or `"eu"`.
+     * @param string $apiEndpoint a base URL (no path), or the shorthands `"global"` or `"eu"`.
+     */
+    public function setApiEndpoint(string $apiEndpoint): self
+    {
+        if ($apiEndpoint != "global" && $apiEndpoint != "eu") {
+            $parts = parse_url($apiEndpoint);
+            if ($parts === false || empty($parts["scheme"]) || empty($parts["host"])) {
+                throw new Exception("Invalid argument '" . $apiEndpoint . "' to setApiEndpoint, it must be a base URL or one of the shorthands 'global' or 'eu'.");
+            }
+            $apiEndpoint = $parts["scheme"] . "://" . $parts["host"] . (isset($parts["port"]) ? ":" . $parts["port"] : "");
+        }
+        $this->apiEndpoint = $apiEndpoint;
+        return $this;
+    }
+
+    /**
+     * @param string $siteverifyEndpoint a base URL (no path), or the shorthands `"global"` or `"eu"`.
+     *
+     * @deprecated Use `setApiEndpoint` instead. $siteverifyEndpoint will be removed in a future version.
      */
     public function setSiteverifyEndpoint(string $siteverifyEndpoint): self
     {
-        if ($siteverifyEndpoint != "global" && $siteverifyEndpoint != "eu" && substr($siteverifyEndpoint, 0, 4) != "http") {
-            throw new Exception("Invalid argument '" . $siteverifyEndpoint . "' to setSiteverifyEndpoint, it must be a full URL or one of the shorthands 'global' or 'eu'.");
+        if ($siteverifyEndpoint != "global" && $siteverifyEndpoint != "eu") {
+            $parts = parse_url($siteverifyEndpoint);
+            if ($parts === false || empty($parts["scheme"]) || empty($parts["host"])) {
+                throw new Exception("Invalid argument '" . $siteverifyEndpoint . "' to setSiteverifyEndpoint, it must be a base URL or one of the shorthands 'global' or 'eu'.");
+            }
+            $siteverifyEndpoint = $parts["scheme"] . "://" . $parts["host"] . (isset($parts["port"]) ? ":" . $parts["port"] : "");
         }
         $this->siteverifyEndpoint = $siteverifyEndpoint;
         return $this;

--- a/src/errors.php
+++ b/src/errors.php
@@ -39,6 +39,15 @@ class ErrorCodes
     /** (200) The response has already been used. */
     public static $ResponseDuplicate = "response_duplicate";
 
+    /** (200) The Risk Intelligence token is invalid. */
+    public static $TokenInvalid = "token_invalid";
+
+    /** (200) The Risk Intelligence token has expired. */
+    public static $TokenExpired = "token_expired";
+
+    /** (400) The Risk Intelligence token is missing from the request. */
+    public static $TokenMissing = "token_missing";
+
     /** (400) Something else is wrong with your request, e.g. the request body was empty. */
     public static $BadRequest = "bad_request";
 }

--- a/src/response.php
+++ b/src/response.php
@@ -185,3 +185,38 @@ class RiskIntelligenceRetrieveResponseData
         return $instance;
     }
 }
+
+class RiskIntelligenceRetrieveResponse
+{
+    /** @var bool */
+    public $success;
+    /** @var RiskIntelligenceRetrieveResponseData|null */
+    public $data;
+    /** @var APIResponseError|null */
+    public $error;
+
+    public static function fromJson($json): ?RiskIntelligenceRetrieveResponse
+    {
+        $d = json_decode($json);
+        if ($d == null || !is_object($d)) {
+            return null;
+        }
+
+        $instance = new self();
+        $instance->success = false;
+        if (isset($d->success)) {
+            $instance->success = $d->success;
+        }
+
+
+        if (isset($d->data)) {
+            $instance->data = RiskIntelligenceRetrieveResponseData::fromStdClass($d->data);
+        }
+
+        if (isset($d->error)) {
+            $instance->error = APIResponseError::fromStdClass($d->error);
+        }
+
+        return $instance;
+    }
+}

--- a/src/response.php
+++ b/src/response.php
@@ -129,7 +129,7 @@ class RiskIntelligenceRetrieveTokenData
     /** @var DateTimeImmutable Timestamp when the token expires. */
     public $expires_at;
     /** @var int Number of times the token has been used. */
-    public $num_users;
+    public $num_uses;
     /** @var string The origin of the site where the token was generated. */
     public $origin;
 

--- a/src/response.php
+++ b/src/response.php
@@ -67,6 +67,11 @@ class VerifyResponseData
      * If Risk Intelligence is not enabled for your Friendly Captcha account, this field will be null.
      */
     public $risk_intelligence;
+    /**
+     * @var array<string, mixed>|null The raw Risk Intelligence data as an associative array.
+     * If Risk Intelligence is not enabled for your Friendly Captcha account, this field will be null.
+     */
+    public $risk_intelligence_raw;
 
     public static function fromJson($json): ?VerifyResponseData
     {
@@ -83,6 +88,7 @@ class VerifyResponseData
         $instance->event_id = $obj->event_id;
         $instance->challenge = VerifyResponseChallengeData::fromStdClass($obj->challenge);
         $instance->risk_intelligence = isset($obj->risk_intelligence) ? RiskIntelligenceData::fromStdClass($obj->risk_intelligence) : null;
+        $instance->risk_intelligence_raw = isset($obj->risk_intelligence) ? json_decode(json_encode($obj->risk_intelligence), true) : null;
         return $instance;
     }
 }
@@ -166,6 +172,8 @@ class RiskIntelligenceRetrieveResponseData
     public $token;
     /** @var RiskIntelligenceData Risk information retrieved with the provided token. */
     public $risk_intelligence;
+    /** @var array<string, mixed> The raw Risk Intelligence data as an associative array. */
+    public $risk_intelligence_raw;
 
     public static function fromJson($json): ?RiskIntelligenceRetrieveResponseData
     {
@@ -182,6 +190,7 @@ class RiskIntelligenceRetrieveResponseData
         $instance->event_id = $obj->event_id;
         $instance->token = RiskIntelligenceRetrieveTokenData::fromStdClass($obj->token);
         $instance->risk_intelligence = RiskIntelligenceData::fromStdClass($obj->risk_intelligence);
+        $instance->risk_intelligence_raw = json_decode(json_encode($obj->risk_intelligence), true);
         return $instance;
     }
 }

--- a/src/response.php
+++ b/src/response.php
@@ -62,6 +62,11 @@ class VerifyResponseData
     public $event_id;
     /** @var VerifyResponseChallengeData Information about the challenge that was solved. */
     public $challenge;
+    /**
+     * @var RiskIntelligenceData|null Risk Intelligence data about the solver of the challenge.
+     * If Risk Intelligence is not enabled for your Friendly Captcha account, this field will be null.
+     */
+    public $risk_intelligence;
 
     public static function fromJson($json): ?VerifyResponseData
     {
@@ -77,6 +82,7 @@ class VerifyResponseData
         $instance = new self();
         $instance->event_id = $obj->event_id;
         $instance->challenge = VerifyResponseChallengeData::fromStdClass($obj->challenge);
+        $instance->risk_intelligence = isset($obj->risk_intelligence) ? RiskIntelligenceData::fromStdClass($obj->risk_intelligence) : null;
         return $instance;
     }
 }

--- a/src/response.php
+++ b/src/response.php
@@ -6,6 +6,31 @@ namespace FriendlyCaptcha\SDK;
 
 use DateTimeImmutable;
 
+class APIResponseError
+{
+    /** @var string */
+    public $error_code;
+    /** @var string */
+    public $detail;
+
+    public static function fromJson($json): ?APIResponseError
+    {
+        $data = json_decode($json);
+        if ($data == null || !is_object($data)) {
+            return null;
+        }
+        return self::fromStdClass($data);
+    }
+
+    public static function fromStdClass($obj): APIResponseError
+    {
+        $instance = new self();
+        $instance->error_code = $obj->error_code;
+        $instance->detail = $obj->detail;
+        return $instance;
+    }
+}
+
 class VerifyResponseChallengeData
 {
     /** @var DateTimeImmutable */
@@ -19,10 +44,7 @@ class VerifyResponseChallengeData
         if ($data == null || !is_object($data)) {
             return null;
         }
-        $instance = new self();
-        $instance->timestamp = DateTimeImmutable::createFromFormat("c", $data->timestamp);
-        $instance->origin = $data->origin;
-        return $instance;
+        return self::fromStdClass($data);
     }
 
     public static function fromStdClass($obj): VerifyResponseChallengeData
@@ -36,7 +58,9 @@ class VerifyResponseChallengeData
 
 class VerifyResponseData
 {
-    /** @var VerifyResponseChallengeData */
+    /** @var string Unique identifier for this siteverify call. */
+    public $event_id;
+    /** @var VerifyResponseChallengeData Information about the challenge that was solved. */
     public $challenge;
 
     public static function fromJson($json): ?VerifyResponseData
@@ -45,43 +69,14 @@ class VerifyResponseData
         if ($data == null || !is_object($data)) {
             return null;
         }
-        $instance = new self();
-        $instance->challenge = VerifyResponseChallengeData::fromStdClass($data->challenge);
-        return $instance;
+        return self::fromStdClass($data);
     }
 
     public static function fromStdClass($obj): VerifyResponseData
     {
         $instance = new self();
+        $instance->event_id = $obj->event_id;
         $instance->challenge = VerifyResponseChallengeData::fromStdClass($obj->challenge);
-        return $instance;
-    }
-}
-
-class VerifyResponseError
-{
-    /** @var string */
-    public $error_code;
-    /** @var string */
-    public $detail;
-
-    public static function fromJson($json): ?VerifyResponseError
-    {
-        $data = json_decode($json);
-        if ($data == null || !is_object($data)) {
-            return null;
-        }
-        $instance = new self();
-        $instance->error_code = $data->error_code;
-        $instance->detail = $data->detail;
-        return $instance;
-    }
-
-    public static function fromStdClass($obj): VerifyResponseError
-    {
-        $instance = new self();
-        $instance->error_code = $obj->error_code;
-        $instance->detail = $obj->detail;
         return $instance;
     }
 }
@@ -92,7 +87,7 @@ class VerifyResponse
     public $success;
     /** @var VerifyResponseData|null */
     public $data;
-    /** @var VerifyResponseError|null */
+    /** @var APIResponseError|null */
     public $error;
 
     public static function fromJson($json): ?VerifyResponse
@@ -114,9 +109,73 @@ class VerifyResponse
         }
 
         if (isset($d->error)) {
-            $instance->error = VerifyResponseError::fromStdClass($d->error);
+            $instance->error = APIResponseError::fromStdClass($d->error);
         }
 
+        return $instance;
+    }
+}
+
+class RiskIntelligenceRetrieveTokenData
+{
+    /** @var DateTimeImmutable Timestamp when the token was generated. */
+    public $timestamp;
+    /** @var DateTimeImmutable Timestamp when the token expires. */
+    public $expires_at;
+    /** @var int Number of times the token has been used. */
+    public $num_users;
+    /** @var string The origin of the site where the token was generated. */
+    public $origin;
+
+    public static function fromJson($json): ?RiskIntelligenceRetrieveTokenData
+    {
+        $data = json_decode($json);
+        if ($data == null || !is_object($data)) {
+            return null;
+        }
+        $instance = new self();
+        $instance->timestamp = DateTimeImmutable::createFromFormat("c", $data->timestamp);
+        $instance->expires_at = DateTimeImmutable::createFromFormat("c", $data->expires_at);
+        $instance->num_uses = $data->num_uses;
+        $instance->origin = $data->origin;
+        return $instance;
+    }
+
+    public static function fromStdClass($obj): RiskIntelligenceRetrieveTokenData
+    {
+        $instance = new self();
+        $instance->timestamp = DateTimeImmutable::createFromFormat("c", $obj->timestamp);
+        $instance->expires_at = DateTimeImmutable::createFromFormat("c", $obj->expires_at);
+        $instance->num_uses = $obj->num_uses;
+        $instance->origin = $obj->origin;
+        return $instance;
+    }
+}
+
+class RiskIntelligenceRetrieveResponseData
+{
+    /** @var string Unique identifier for this Risk Intelligence retrieve call. */
+    public $event_id;
+    /** @var RiskIntelligenceRetrieveTokenData Metadata about the token used for retrieval. */
+    public $token;
+    /** @var RiskIntelligenceData Risk information retrieved with the provided token. */
+    public $risk_intelligence;
+
+    public static function fromJson($json): ?RiskIntelligenceRetrieveResponseData
+    {
+        $data = json_decode($json);
+        if ($data == null || !is_object($data)) {
+            return null;
+        }
+        return self::fromStdClass($data);
+    }
+
+    public static function fromStdClass($obj): RiskIntelligenceRetrieveResponseData
+    {
+        $instance = new self();
+        $instance->event_id = $obj->event_id;
+        $instance->token = RiskIntelligenceRetrieveTokenData::fromStdClass($obj->token);
+        $instance->risk_intelligence = RiskIntelligenceData::fromStdClass($obj->risk_intelligence);
         return $instance;
     }
 }

--- a/src/result.php
+++ b/src/result.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FriendlyCaptcha\SDK;
 
-use FriendlyCaptcha\SDK\VerifyResponse;
+use FriendlyCaptcha\SDK\{VerifyResponse, RiskIntelligenceRetrieveResponse};
 use Exception;
 
 class VerifyResult
@@ -145,5 +145,115 @@ class VerifyResult
             return true;
         }
         return $this->status == 200 && !$this->isRequestError() && !$this->isDecodeError();
+    }
+}
+
+/**
+ * The result of a risk intelligence retrieve request.
+ */
+class RiskIntelligenceRetrieveResult
+{
+    /** @var int The HTTP status code of the response. */
+    public $status;
+
+    /** @var RiskIntelligenceRetrieveResponse|null The response body. */
+    public $response;
+
+    /**
+     * `null` if Risk Intelligence data could be retrieved; in other words we got a 200 response.
+     * \
+     * Otherwise this will be set to one of the error codes in `ErrorCodes`:
+     * * `ErrorCodes::$RequestFailed`
+     * * `ErrorCodes::$FailedDueToClientError` (see $response->error for more details, your API key might be wrong).
+     * * `ErrorCodes::$FailedToEncodeRequest`
+     * * `ErrorCodes::$FailedToDecodeResponse`
+     *
+     * @var string|null
+     */
+    public $errorCode = null;
+
+    /**
+     * Get the response that was sent from the server.
+     * This can be null if the request to the API could not be made succesfully.
+     */
+    public function getResponse(): ?RiskIntelligenceRetrieveResponse
+    {
+        return $this->response;
+    }
+
+    /**
+     * Get the error field from the response as was returned by the API, or null if the field is not present.
+     */
+    public function getResponseError(): ?APIResponseError
+    {
+        if ($this->response === null) {
+            return null;
+        }
+        return $this->response->error;
+    }
+
+    /**
+     * Something went wrong on the client side, this generally means your configuration is wrong.
+     * Check your secrets (API key) and sitekey.
+     *
+     * See `$this->response->error` for more details.
+     */
+    public function isClientError(): bool
+    {
+        return $this->errorCode === ErrorCodes::$FailedDueToClientError;
+    }
+
+    /**
+     * Failed to encode the Risk Intelligence token.
+     */
+    public function isEncodeError(): bool
+    {
+        return $this->errorCode === ErrorCodes::$FailedToEncodeRequest;
+    }
+
+    /**
+     * Something went wrong making the request to the Friendly Captcha API, perhaps there is a network connection issue?
+     */
+    public function isRequestError(): bool
+    {
+        return $this->errorCode === ErrorCodes::$RequestFailed;
+    }
+
+    /**
+     * Something went wrong decoding the response from the Friendly Captcha API.
+     */
+    public function isDecodeError(): bool
+    {
+        return $this->errorCode === ErrorCodes::$FailedToDecodeResponse;
+    }
+
+    /**
+     * Whether the request to retrieve risk intelligence was completed. In other words: the API responded with status 200.
+     * If this is false, you should notify yourself and use `getResponseError()` to see what is wrong.
+     */
+    public function wasAbleToRetrieve(): bool
+    {
+        // If we failed to encode, we actually consider `wasAbleToRetrieve` to be true. This is because we don't want to
+        // alert on failed encoding: an attacker could send such malformed data that it fails to encode.
+        if ($this->isEncodeError()) {
+            return true;
+        }
+
+        return $this->status == 200 && !$this->isRequestError() && !$this->isDecodeError();
+    }
+
+    /**
+     * Whether the Risk Intelligence data was successfully retrieved and is valid.
+     */
+    public function isValid(): bool {
+        if ($this->wasAbleToRetrieve()) {
+            if ($this->isEncodeError()) {
+                return false;
+            }
+            if ($this->response != null) {
+                return $this->response->success;
+            }
+        }
+        return false;
     }
 }

--- a/src/result.php
+++ b/src/result.php
@@ -116,7 +116,7 @@ class VerifyResult
     /**
      * Get the error field from the response as was returned by the API, or null if the field is not present.
      */
-    public function getResponseError(): ?VerifyResponseError
+    public function getResponseError(): ?APIResponseError
     {
         if ($this->response === null) {
             return null;

--- a/src/risk_intelligence.php
+++ b/src/risk_intelligence.php
@@ -1,0 +1,736 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendlyCaptcha\SDK;
+
+class RiskScoresData
+{
+    /**
+     * RiskScoresData summarizes the entire risk intelligence assessment into scores per category.
+     *
+     * Available when the Risk Scores module is enabled for your account.
+     * Null when the Risk Scores module is not enabled for your account.
+     */
+
+    /** @var int Overall risk score combining all signals. */
+    public $overall;
+    /**
+     * @var int Network-related risk score. Captures likelihood of automation/malicious activity based on
+     * IP address, ASN, reputation, geolocation, past abuse from this network, and other network signals.
+     */
+    public $network;
+    /**
+     * @var int Browser-related risk score. Captures likelihood of automation, malicious activity or browser spoofing based on
+     * user agent consistency, automation traces, past abuse, and browser characteristics.
+     */
+    public $browser;
+
+    public static function fromStdClass($obj): RiskScoresData
+    {
+        $instance = new self();
+        $instance->overall = $obj->overall;
+        $instance->network = $obj->network;
+        $instance->browser = $obj->browser;
+        return $instance;
+    }
+}
+
+class NetworkAutonomousSystemData
+{
+    /**
+     * NetworkAutonomousSystemData contains information about the AS that owns the IP.
+     *
+     * Available when the IP Intelligence module is enabled for your account.
+     * Null when the IP Intelligence module is not enabled for your account.
+     */
+
+    /**
+     * @var int Autonomous System Number (ASN) identifier.
+     * Example: 3209 for Vodafone GmbH
+     */
+    public $number;
+    /**
+     * @var string Name of the autonomous system. This is usually a short name or handle.
+     * Example: "VODANET"
+     */
+    public $name;
+    /**
+     * @var string Company is the organization name that owns the ASN.
+     * Example: "Vodafone GmbH"
+     */
+    public $company;
+    /**
+     * @var string Description of the company that owns the ASN.
+     * Example: "Provides mobile and fixed broadband and telecommunication services to consumers and businesses."
+     */
+    public $description;
+    /**
+     * @var string Domain name associated with the ASN.
+     * Example: "vodafone.de"
+     */
+    public $domain;
+    /**
+     * @var string Two-letter ISO 3166-1 alpha-2 country code where the ASN is registered.
+     * Example: "DE"
+     */
+    public $country;
+    /**
+     * @var string Regional Internet Registry that allocated the ASN.
+     * Example: "RIPE"
+     */
+    public $rir;
+    /**
+     * @var string IP route associated with the ASN in CIDR notation.
+     * Example: "88.64.0.0/12"
+     */
+    public $route;
+    /**
+     * @var string Autonomous system type.
+     * Example: "isp"
+     */
+    public $type;
+
+    public static function fromStdClass($obj): NetworkAutonomousSystemData
+    {
+        $instance = new self();
+        $instance->number = $obj->number;
+        $instance->name = $obj->name;
+        $instance->company = $obj->company;
+        $instance->description = $obj->description;
+        $instance->domain = $obj->domain;
+        $instance->country = $obj->country;
+        $instance->rir = $obj->rir;
+        $instance->route = $obj->route;
+        $instance->type = $obj->type;
+        return $instance;
+    }
+}
+
+class NetworkGeolocationCountryData
+{
+    /** NetworkGeolocationCountryData contains detailed country data. */
+
+    /**
+     * @var string Two-letter ISO 3166-1 alpha-2 country code.
+     * Example: "DE"
+     */
+    public $iso2;
+    /**
+     * @var string Three-letter ISO 3166-1 alpha-3 country code.
+     * Example: "DEU"
+     */
+    public $iso3;
+    /**
+     * @var string English name of the country.
+     * Example: "Germany"
+     */
+    public $name;
+    /**
+     * @var string Native name of the country.
+     * Example: "Deutschland"
+     */
+    public $name_native;
+    /**
+     * @var string Major world region.
+     * Example: "Europe"
+     */
+    public $region;
+    /**
+     * @var string More specific world region.
+     * Example: "Western Europe"
+     */
+    public $subregion;
+    /**
+     * @var string ISO 4217 currency code.
+     * Example: "EUR"
+     */
+    public $currency;
+    /**
+     * @var string Full name of the currency.
+     * Example: "Euro"
+     */
+    public $currency_name;
+    /**
+     * @var string International dialing code.
+     * Example: "49"
+     */
+    public $phone_code;
+    /**
+     * @var string Name of the capital city.
+     * Example: "Berlin"
+     */
+    public $capital;
+
+    public static function fromStdClass($obj): NetworkGeolocationCountryData
+    {
+        $instance = new self();
+        $instance->iso2 = $obj->iso2;
+        $instance->iso3 = $obj->iso3;
+        $instance->name = $obj->name;
+        $instance->name_native = $obj->name_native;
+        $instance->region = $obj->region;
+        $instance->subregion = $obj->subregion;
+        $instance->currency = $obj->currency;
+        $instance->currency_name = $obj->currency_name;
+        $instance->phone_code = $obj->phone_code;
+        $instance->capital = $obj->capital;
+        return $instance;
+    }
+}
+
+class NetworkGeolocationData
+{
+    /**
+     * NetworkGeolocationData contains geographic location of the IP address.
+     *
+     * Available when the IP Intelligence module is enabled.
+     * Null when the IP Intelligence module is not enabled.
+     */
+
+    /** @var NetworkGeolocationCountryData Country information. */
+    public $country;
+    /**
+     * @var string City name. Empty string if unknown.
+     * Example: "Eschborn"
+     */
+    public $city;
+    /**
+     * @var string State, region, or province. Empty string if unknown.
+     * Example: "Hessen"
+     */
+    public $state;
+
+    public static function fromStdClass($obj): NetworkGeolocationData
+    {
+        $instance = new self();
+        $instance->country = NetworkGeolocationCountryData::fromStdClass($obj->country);
+        $instance->city = $obj->city;
+        $instance->state = $obj->state;
+        return $instance;
+    }
+}
+
+class NetworkAbuseContactData
+{
+    /**
+     * NetworkAbuseContactData contains contact details for reporting abuse.
+     *
+     * Available when the IP Intelligence module is enabled.
+     * Null when the IP Intelligence module is not enabled.
+     */
+
+    /**
+     * @var string Postal address of the abuse contact.
+     * Example: "Vodafone GmbH, Campus Eschborn, Duesseldorfer Strasse 15, D-65760 Eschborn, Germany"
+     */
+    public $address;
+    /**
+     * @var string Name of the abuse contact person or team.
+     * Example: "Vodafone Germany IP Core Backbone"
+     */
+    public $name;
+    /**
+     * @var string Abuse contact email address.
+     * Example: "abuse.de@vodafone.com"
+     */
+    public $email;
+    /**
+     * @var string Abuse contact phone number.
+     * Example: "+49 6196 52352105"
+     */
+    public $phone;
+
+    public static function fromStdClass($obj): NetworkAbuseContactData
+    {
+        $instance = new self();
+        $instance->address = $obj->address;
+        $instance->name = $obj->name;
+        $instance->email = $obj->email;
+        $instance->phone = $obj->phone;
+        return $instance;
+    }
+}
+
+class NetworkAnonymizationData
+{
+    /**
+     * NetworkAnonymizationData contains detection of VPNs, proxies, and anonymization services.
+     *
+     * Available when the Anonymization Detection module is enabled.
+     * Null when the Anonymization Detection module is not enabled.
+     */
+
+    /** @var int Likelihood that the IP is from a VPN service. */
+    public $vpn_score;
+    /** @var int Likelihood that the IP is from a proxy service. */
+    public $proxy_score;
+    /** @var bool Whether the IP is a Tor exit node. */
+    public $tor;
+    /** @var bool Whether the IP is from iCloud Private Relay. */
+    public $icloud_private_relay;
+
+    public static function fromStdClass($obj): NetworkAnonymizationData
+    {
+        $instance = new self();
+        $instance->vpn_score = $obj->vpn_score;
+        $instance->proxy_score = $obj->proxy_score;
+        $instance->tor = $obj->tor;
+        $instance->icloud_private_relay = $obj->icloud_private_relay;
+        return $instance;
+    }
+}
+
+class NetworkData
+{
+    /** NetworkData contains information about the network. */
+
+    /**
+     * @var string IP address used when requesting the challenge.
+     * Example: "88.64.4.22"
+     */
+    public $ip;
+    /**
+     * @var NetworkAutonomousSystemData|null Autonomous System information.
+     *
+     * Available when the IP Intelligence module is enabled.
+     * Null when the IP Intelligence module is not enabled.
+     */
+    public $as;
+    /**
+     * @var NetworkGeolocationData|null Geolocation information.
+     *
+     * Available when the IP Intelligence module is enabled.
+     * Null when the IP Intelligence module is not enabled.
+     */
+    public $geolocation;
+    /**
+     * @var NetworkAbuseContactData|null Abuse contact information.
+     *
+     * Available when the IP Intelligence module is enabled.
+     * Null when the IP Intelligence module is not enabled.
+     */
+    public $abuse_contact;
+    /**
+     * @var NetworkAnonymizationData|null IP masking/anonymization information.
+     *
+     * Available when the Anonymization Detection module is enabled.
+     * Null when the Anonymization Detection module is not enabled.
+     */
+    public $anonymization;
+
+    public static function fromStdClass($obj): NetworkData
+    {
+        $instance = new self();
+        $instance->ip = $obj->ip;
+        $instance->as = isset($obj->as) ? NetworkAutonomousSystemData::fromStdClass($obj->as) : null;
+        $instance->geolocation = isset($obj->geolocation) ? NetworkGeolocationData::fromStdClass($obj->geolocation) : null;
+        $instance->abuse_contact = isset($obj->abuse_contact) ? NetworkAbuseContactData::fromStdClass($obj->abuse_contact) : null;
+        $instance->anonymization = isset($obj->anonymization) ? NetworkAnonymizationData::fromStdClass($obj->anonymization) : null;
+        return $instance;
+    }
+}
+
+class ClientTimeZoneData
+{
+    /**
+     * ClientTimeZoneData contains IANA time zone data.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+
+    /**
+     * @var string IANA time zone name reported by the browser.
+     * Example: "America/New_York" or "Europe/Berlin"
+     */
+    public $name;
+    /**
+     * @var string Two-letter ISO 3166-1 alpha-2 country code derived from the time zone.
+     * "XU" if timezone is missing or cannot be mapped to a country (e.g., "Etc/UTC").
+     * Example: "US" or "DE"
+     */
+    public $country_iso2;
+
+    public static function fromStdClass($obj): ClientTimeZoneData
+    {
+        $instance = new self();
+        $instance->name = $obj->name;
+        $instance->country_iso2 = $obj->country_iso2;
+        return $instance;
+    }
+}
+
+class ClientBrowserData
+{
+    /**
+     * ClientBrowserData contains detected browser details.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+
+    /**
+     * @var string Unique browser identifier. Empty string if browser could not be identified.
+     * Example: "firefox", "chrome", "chrome_android", "edge", "safari", "safari_ios", "webview_ios"
+     */
+    public $id;
+    /**
+     * @var string Human-readable browser name. Empty string if browser could not be identified.
+     * Example: "Firefox", "Chrome", "Edge", "Safari", "Safari on iOS", "WebView on iOS"
+     */
+    public $name;
+    /**
+     * @var string Browser version name. Assumed to be the most recent release matching the signature if exact version unknown. Empty if unknown.
+     * Example: "146.0" or "16.5"
+     */
+    public $version;
+    /**
+     * @var string Release date of the browser version in "YYYY-MM-DD" format. Empty string if unknown.
+     * Example: "2026-01-28"
+     */
+    public $release_date;
+
+    public static function fromStdClass($obj): ClientBrowserData
+    {
+        $instance = new self();
+        $instance->id = $obj->id;
+        $instance->name = $obj->name;
+        $instance->version = $obj->version;
+        $instance->release_date = $obj->release_date;
+        return $instance;
+    }
+}
+
+class ClientBrowserEngineData
+{
+    /**
+     * ClientBrowserEngineData contains detected rendering engine details.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+
+    /**
+     * @var string Unique rendering engine identifier. Empty string if engine could not be identified.
+     * Example: "gecko", "blink", "webkit"
+     */
+    public $id;
+    /**
+     * @var string Human-readable engine name. Empty string if engine could not be identified.
+     * Example: "Gecko", "Blink", "WebKit"
+     */
+    public $name;
+    /**
+     * @var string Rendering engine version. Assumed to be the most recent release matching the signature if exact version unknown. Empty if unknown.
+     * Example: "146.0" or "16.5"
+     */
+    public $version;
+
+    public static function fromStdClass($obj): ClientBrowserEngineData
+    {
+        $instance = new self();
+        $instance->id = $obj->id;
+        $instance->name = $obj->name;
+        $instance->version = $obj->version;
+        return $instance;
+    }
+}
+
+class ClientDeviceData
+{
+    /**
+     * ClientDeviceData contains detected device details.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+
+    /**
+     * @var string Device type.
+     * Example: "desktop", "mobile", "tablet"
+     */
+    public $type;
+    /**
+     * @var string Device brand.
+     * Example: "Apple", "Samsung", "Google"
+     */
+    public $brand;
+    /**
+     * @var string Device model name.
+     * Example: "iPhone 17", "Galaxy S21 (SM-G991B)", "Pixel 10"
+     */
+    public $model;
+
+    public static function fromStdClass($obj): ClientDeviceData
+    {
+        $instance = new self();
+        $instance->type = $obj->type;
+        $instance->brand = $obj->brand;
+        $instance->model = $obj->model;
+        return $instance;
+    }
+}
+
+class ClientOSData
+{
+    /**
+     * ClientOSData contains detected OS details.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+
+    /**
+     * @var string Unique operating system identifier. Empty string if OS could not be identified.
+     * Example: "windows", "macos", "ios", "android", "linux"
+     */
+    public $id;
+    /**
+     * @var string Human-readable operating system name. Empty string if OS could not be identified.
+     * Example: "Windows", "macOS", "iOS", "Android", "Linux"
+     */
+    public $name;
+    /**
+     * @var string Operating system version.
+     * Example: "10", "11.2.3", "14.4"
+     */
+    public $version;
+
+    public static function fromStdClass($obj): ClientOSData
+    {
+        $instance = new self();
+        $instance->id = $obj->id;
+        $instance->name = $obj->name;
+        $instance->version = $obj->version;
+        return $instance;
+    }
+}
+
+class TLSSignatureData
+{
+    /**
+     * TLSSignatureData contains TLS client hello signatures.
+     *
+     * Available when the Bot Detection module is enabled.
+     * Null when the Bot Detection module is not enabled.
+     */
+
+    /**
+     * @var string JA3 hash.
+     * Example: "d87a30a5782a73a83c1544bb06332780"
+     */
+    public $ja3;
+    /**
+     * @var string JA3N hash.
+     * Example: "28ecc2d2875b345cecbb632b12d8c1e0"
+     */
+    public $ja3n;
+    /**
+     * @var string JA4 signature.
+     * Example: "t13d1516h2_8daaf6152771_02713d6af862"
+     */
+    public $ja4;
+
+    public static function fromStdClass($obj): TLSSignatureData
+    {
+        $instance = new self();
+        $instance->ja3 = $obj->ja3;
+        $instance->ja3n = $obj->ja3n;
+        $instance->ja4 = $obj->ja4;
+        return $instance;
+    }
+}
+
+class ClientAutomationKnownBotData
+{
+    /** ClientAutomationKnownBotData contains detected known bot details. */
+
+    /** @var bool Whether a known bot was detected. */
+    public $detected;
+    /**
+     * @var string Bot identifier. Empty if no bot detected.
+     * Example: "googlebot", "bingbot", "chatgpt"
+     */
+    public $id;
+    /**
+     * @var string Human-readable bot name. Empty if no bot detected.
+     * Example: "Googlebot", "Bingbot", "ChatGPT"
+     */
+    public $name;
+    /** @var string Bot type classification. Empty if no bot detected. */
+    public $type;
+    /**
+     * @var string Link to bot documentation. Empty if no bot detected.
+     * Example: "https://developers.google.com/search/docs/crawling-indexing/googlebot"
+     */
+    public $url;
+
+    public static function fromStdClass($obj): ClientAutomationKnownBotData
+    {
+        $instance = new self();
+        $instance->detected = $obj->detected;
+        $instance->id = $obj->id;
+        $instance->name = $obj->name;
+        $instance->type = $obj->type;
+        $instance->url = $obj->url;
+        return $instance;
+    }
+}
+
+class ClientAutomationToolData
+{
+    /** ClientAutomationToolData contains detected automation tool details. */
+
+    /** @var bool Whether an automation tool was detected. */
+    public $detected;
+    /**
+     * @var string Automation tool identifier. Empty if no tool detected.
+     * Example: "puppeteer", "selenium", "playwright"
+     */
+    public $id;
+    /**
+     * @var string Human-readable tool name. Empty if no tool detected.
+     * Example: "Puppeteer", "Selenium WebDriver", "Playwright"
+     */
+    public $name;
+    /** @var string Automation tool type. Empty if no tool detected. */
+    public $type;
+
+    public static function fromStdClass($obj): ClientAutomationToolData
+    {
+        $instance = new self();
+        $instance->detected = $obj->detected;
+        $instance->id = $obj->id;
+        $instance->name = $obj->name;
+        $instance->type = $obj->type;
+        return $instance;
+    }
+}
+
+class ClientAutomationData
+{
+    /**
+     * ClientAutomationData contains information about detected automation.
+     *
+     * Available when the Bot Detection module is enabled.
+     * Null when the Bot Detection module is not enabled.
+     */
+
+    /** @var ClientAutomationToolData Detected automation tool information. */
+    public $automation_tool;
+    /** @var ClientAutomationKnownBotData Detected known bot information. */
+    public $known_bot;
+
+    public static function fromStdClass($obj): ClientAutomationData
+    {
+        $instance = new self();
+        $instance->automation_tool = ClientAutomationToolData::fromStdClass($obj->automation_tool);
+        $instance->known_bot = ClientAutomationKnownBotData::fromStdClass($obj->known_bot);
+        return $instance;
+    }
+}
+
+class ClientData
+{
+    /** ClientData contains information about the user agent and device. */
+
+    /**
+     * @var string User-Agent HTTP header value.
+     * Example: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:146.0) Gecko/20100101 Firefox/146.0"
+     */
+    public $header_user_agent;
+    /**
+     * @var ClientTimeZoneData|null Time zone information.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+    public $time_zone;
+    /**
+     * @var ClientBrowserData|null Browser information.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+    public $browser;
+    /**
+     * @var ClientBrowserEngineData|null Browser engine information.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+    public $browser_engine;
+    /**
+     * @var ClientDeviceData|null Device information.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+    public $device;
+    /**
+     * @var ClientOSData|null OS information.
+     *
+     * Available when the Browser Identification module is enabled.
+     * Null when the Browser Identification module is not enabled.
+     */
+    public $os;
+    /**
+     * @var TLSSignatureData|null TLS signatures.
+     *
+     * Available when the Bot Detection module is enabled.
+     * Null when the Bot Detection module is not enabled.
+     */
+    public $tls_signature;
+    /**
+     * @var ClientAutomationData|null Automation detection data.
+     *
+     * Available when the Bot Detection module is enabled.
+     * Null when the Bot Detection module is not enabled.
+     */
+    public $automation;
+
+    public static function fromStdClass($obj): ClientData
+    {
+        $instance = new self();
+        $instance->header_user_agent = $obj->header_user_agent;
+        $instance->time_zone = isset($obj->time_zone) ? ClientTimeZoneData::fromStdClass($obj->time_zone) : null;
+        $instance->browser = isset($obj->browser) ? ClientBrowserData::fromStdClass($obj->browser) : null;
+        $instance->browser_engine = isset($obj->browser_engine) ? ClientBrowserEngineData::fromStdClass($obj->browser_engine) : null;
+        $instance->device = isset($obj->device) ? ClientDeviceData::fromStdClass($obj->device) : null;
+        $instance->os = isset($obj->os) ? ClientOSData::fromStdClass($obj->os) : null;
+        $instance->tls_signature = isset($obj->tls_signature) ? TLSSignatureData::fromStdClass($obj->tls_signature) : null;
+        $instance->automation = isset($obj->automation) ? ClientAutomationData::fromStdClass($obj->automation) : null;
+        return $instance;
+    }
+}
+
+class RiskIntelligenceData
+{
+    /**
+     * RiskIntelligenceData contains all risk intelligence information.
+     *
+     * Field availability depends on enabled modules.
+     */
+
+    /**
+     * @var RiskScoresData|null Risk scores from various signals, these summarize the risk intelligence assessment.
+     *
+     * Available when the Risk Scores module is enabled.
+     * Null when the Risk Scores module is not enabled.
+     */
+    public $risk_scores;
+    /** @var NetworkData Network-related risk intelligence. */
+    public $network;
+    /** @var ClientData Client/device risk intelligence. */
+    public $client;
+
+    public static function fromStdClass($obj): RiskIntelligenceData
+    {
+        $instance = new self();
+        $instance->risk_scores = isset($obj->risk_scores) ? RiskScoresData::fromStdClass($obj->risk_scores) : null;
+        $instance->network = NetworkData::fromStdClass($obj->network);
+        $instance->client = ClientData::fromStdClass($obj->client);
+        return $instance;
+    }
+}

--- a/tests/configTest.php
+++ b/tests/configTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendlyCaptcha\SDK\Test;
+
+use FriendlyCaptcha\SDK\{Client, ClientConfig};
+use Exception;
+
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    public function testConfigWithoutAPIKeyThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("API key is required");
+        $opts = new ClientConfig();
+        $client = new Client($opts);
+    }
+
+    public function testConfigInvalidSiteverifyEndpointThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $opts = new ClientConfig();
+        $opts->setSiteverifyEndpoint("something-invalid-that-is-not-a-url");
+    }
+
+    public function testConfigInvalidApiEndpointThrows(): void
+    {
+        $this->expectException(Exception::class);
+        $opts = new ClientConfig();
+        $opts->setApiEndpoint("something-invalid-that-is-not-a-url");
+    }
+
+    public function testConfigApiEndpointStripsPaths(): void
+    {
+        $opts = new ClientConfig();
+        $opts->setApiEndpoint("https://exmple.com/a/b/c");
+        $this->assertEquals("https://exmple.com", $opts->apiEndpoint);
+    }
+
+    public function testConfigSiteverifyEndpointStripsPaths(): void
+    {
+        $opts = new ClientConfig();
+        $opts->setSiteverifyEndpoint("https://exmple.com/a/b/c");
+        $this->assertEquals("https://exmple.com", $opts->siteverifyEndpoint);
+    }
+}

--- a/tests/retrieveTest.php
+++ b/tests/retrieveTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FriendlyCaptcha\SDK\Test;
+
+use FriendlyCaptcha\SDK\{Client, ClientConfig, RiskIntelligenceRetrieveResponse};
+use Exception;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+const MOCK_SERVER_URL = "http://localhost:1090";
+
+function loadRetrieveSDKTestsFromServer(string $serverURL)
+{
+    $ch = curl_init();
+    curl_setopt($ch, CURLOPT_URL, $serverURL . "/api/v1/riskIntelligence/retrieveTests");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        throw new Exception("Failed to load tests from server " . curl_error($ch) . " " . curl_errno($ch));
+    }
+    curl_close($ch);
+    $json = json_decode($response, true);
+    return $json;
+}
+
+
+final class RiskIntelligenceRetrieveTest extends TestCase
+{
+    public function testNonEncodeableResponse(): void
+    {
+        $opts = new ClientConfig();
+        $opts->setAPIKey("some-key");
+        $client = new Client($opts);
+        $result = $client->retrieveRiskIntelligence("\xB1\x31"); // This fails to encode to JSON in PHP.
+
+        $this->assertTrue($result->isEncodeError());
+        $this->assertFalse($result->isClientError());
+        $this->assertFalse($result->isRequestError());
+        $this->assertFalse($result->isDecodeError());
+        $this->assertTrue($result->wasAbleToRetrieve());
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testNonReachableEndpoint(): void
+    {
+        $opts = new ClientConfig();
+        $opts->setAPIKey("some-key")->setApiEndpoint("https://localhost:9999"); // Assuming there's nothing running on that port..
+        $client = new Client($opts);
+        $result = $client->retrieveRiskIntelligence("my-response");
+
+        $this->assertTrue($result->isRequestError());
+        $this->assertFalse($result->isClientError());
+        $this->assertFalse($result->isEncodeError());
+        $this->assertFalse($result->isDecodeError());
+        $this->assertFalse($result->wasAbleToRetrieve());
+        $this->assertFalse($result->isValid());
+    }
+
+
+
+    public static function sdkMockTestsProvider(): array
+    {
+        $cases = loadRetrieveSDKTestsFromServer(MOCK_SERVER_URL)["tests"];
+        $testCases = array();
+        foreach ($cases as $case) {
+            $testCases[$case["name"]] = array($case);
+        }
+        return $testCases;
+    }
+
+    /**
+     * @dataProvider sdkMockTestsProvider
+     */
+    #[DataProvider('sdkMockTestsProvider')]
+    public function testSDKTestServerCase($test): void
+    {
+        $opts = new ClientConfig();
+        $opts->setAPIKey("some-key")->setApiEndpoint(MOCK_SERVER_URL);
+        $client = new Client($opts);
+        $result = $client->retrieveRiskIntelligence($test["token"]);
+
+        $expectWasAbleToRetrieve = $test["expectation"]["was_able_to_retrieve"];
+        $expectIsValid = $test["expectation"]["is_valid"];
+        $expectIsClientError = $test["expectation"]["is_client_error"];
+        $wasAbleToRetrieve = $result->wasAbleToRetrieve();
+        $isValid = $result->isValid();
+        $isClientError = $result->isClientError();
+
+        $this->assertEquals($expectWasAbleToRetrieve, $wasAbleToRetrieve,
+            "'was_able_to_retrieve' is not as expected: " . json_encode($wasAbleToRetrieve) . " result: " . print_r($result, true));
+
+        $this->assertEquals($expectIsValid, $isValid,
+            "'is_valid' is not as expected: " . json_encode($isValid) . " result: " . print_r($result, true));
+
+        $this->assertEquals($expectIsClientError, $isClientError,
+            "'is_client_error' is not as expected: " . json_encode($isClientError) . " result: " . print_r($result, true));
+
+        $expectedResponse = RiskIntelligenceRetrieveResponse::fromJson(json_encode($test["retrieve_response"]));
+        $actualResponse = $result->getResponse();
+        $this->assertEquals($expectedResponse, $actualResponse);
+    }
+}

--- a/tests/verifyTest.php
+++ b/tests/verifyTest.php
@@ -15,7 +15,7 @@ const MOCK_SERVER_URL = "http://localhost:1090";
 function loadSDKTestsFromServer(string $serverURL)
 {
     $ch = curl_init();
-    curl_setopt($ch, CURLOPT_URL, $serverURL . "/api/v1/tests");
+    curl_setopt($ch, CURLOPT_URL, $serverURL . "/api/v1/captcha/siteverifyTests");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     $response = curl_exec($ch);
     if ($response === false) {

--- a/tests/verifyTest.php
+++ b/tests/verifyTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FriendlyCaptcha\SDK\Test;
 
-use FriendlyCaptcha\SDK\{Client, ClientConfig};
+use FriendlyCaptcha\SDK\{Client, ClientConfig, VerifyResponse};
 use Exception;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -65,7 +65,7 @@ final class VerifyTest extends TestCase
         $cases = loadSDKTestsFromServer(MOCK_SERVER_URL)["tests"];
         $testCases = array();
         foreach ($cases as $case) {
-            $testCases[] = array($case);
+            $testCases[$case["name"]] = array($case);
         }
         return $testCases;
     }
@@ -107,5 +107,9 @@ final class VerifyTest extends TestCase
                 $this->assertTrue($result->shouldAccept(), "non-strict mode should accept when not able to verify");
             }
         }
+
+        $expectedResponse = VerifyResponse::fromJson(json_encode($test["siteverify_response"]));
+        $actualResponse = $result->getResponse();
+        $this->assertEquals($expectedResponse, $actualResponse);
     }
 }

--- a/tests/verifyTest.php
+++ b/tests/verifyTest.php
@@ -29,20 +29,6 @@ function loadSDKTestsFromServer(string $serverURL)
 
 final class VerifyTest extends TestCase
 {
-    public function testConfigWithoutAPIKeyThrows(): void
-    {
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage("API key is required");
-        $opts = new ClientConfig();
-        $client = new Client($opts);
-    }
-    public function testConfigInvalidEndpointThrows(): void
-    {
-        $this->expectException(Exception::class);
-        $opts = new ClientConfig();
-        $opts->setSiteverifyEndpoint("something-invalid-that-is-not-a-url");
-    }
-
     public function testNonEncodeableResponse(): void
     {
         $opts = new ClientConfig();
@@ -61,7 +47,7 @@ final class VerifyTest extends TestCase
     public function testNonReachableEndpoint(): void
     {
         $opts = new ClientConfig();
-        $opts->setAPIKey("some-key")->setSiteverifyEndpoint("https://localhost:9999"); // Assuming there's nothing running on that port..
+        $opts->setAPIKey("some-key")->setApiEndpoint("https://localhost:9999"); // Assuming there's nothing running on that port..
         $client = new Client($opts);
         $result = $client->verifyCaptchaResponse("my-response");
 
@@ -91,7 +77,7 @@ final class VerifyTest extends TestCase
     public function testSDKTestServerCase($test): void
     {
         $opts = new ClientConfig();
-        $opts->setAPIKey("some-key")->setSiteverifyEndpoint(MOCK_SERVER_URL . "/api/v2/captcha/siteverify")->setStrict($test["strict"]); // Assuming there's nothing running on that port..
+        $opts->setAPIKey("some-key")->setApiEndpoint(MOCK_SERVER_URL)->setStrict($test["strict"]);
         $client = new Client($opts);
         $result = $client->verifyCaptchaResponse($test["response"]);
 

--- a/tests/verifyTest.php
+++ b/tests/verifyTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 const MOCK_SERVER_URL = "http://localhost:1090";
 
-function loadSDKTestsFromServer(string $serverURL)
+function loadSiteverifySDKTestsFromServer(string $serverURL)
 {
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $serverURL . "/api/v1/captcha/siteverifyTests");
@@ -62,7 +62,7 @@ final class VerifyTest extends TestCase
 
     public static function sdkMockTestsProvider(): array
     {
-        $cases = loadSDKTestsFromServer(MOCK_SERVER_URL)["tests"];
+        $cases = loadSiteverifySDKTestsFromServer(MOCK_SERVER_URL)["tests"];
         $testCases = array();
         foreach ($cases as $case) {
             $testCases[$case["name"]] = array($case);


### PR DESCRIPTION
Supports Risk Intelligence both standalone and on captcha challenge. Also deprecates `$siteverifyEndpoint` in favor of `$apiEndpoint`. 

Closes https://github.com/FriendlyCaptcha/friendly-captcha/issues/3276